### PR TITLE
Correct metrics & add curator dep. for clustering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,11 @@
             <version>${hazelcast.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-x-discovery</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.lmax</groupId>
             <artifactId>disruptor</artifactId>
             <version>${lmax-disruptor.version}</version>
@@ -304,6 +309,8 @@
                                         implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                     <resource>META-INF/services/io.vertx.core.spi.VerticleFactory
                                     </resource>
+                                    <resource>META-INF/services/io.vertx.core.spi.VertxServiceProvider
+                                    </resource>
                                 </transformer>
                             </transformers>
                             <artifactSet></artifactSet>
@@ -339,6 +346,8 @@
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                     <resource>META-INF/services/io.vertx.core.spi.VerticleFactory
+                                    </resource>
+                                    <resource>META-INF/services/io.vertx.core.spi.VertxServiceProvider
                                     </resource>
                                 </transformer>
                             </transformers>


### PR DESCRIPTION
- Correction of metrics in vertx4, by including
'META-INF/services/io.vertx.core.spi.VertxServiceProvider' in
transformer in pom.xml.
- similar to https://github.com/datakaveri/iudx-resource-server/pull/123
- add curator package needed for zookeeper-hazelcast clustering