### PR TITLE
non-root img for DI server

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -35,9 +35,9 @@ services:
   dev:
     image: iudx/di-dev:latest
     environment:
-      - DI_URL=https://rs.iudx.org.in
+      - DI_URL=https://di.iudx.org.in
       - LOG_LEVEL=INFO
-      - RS_JAVA_OPTS=-Xmx1024m
+      - DI_JAVA_OPTS=-Xmx1024m
     volumes:
       - ./configs/config-dev.json:/usr/share/app/configs/config.json
       - ./configs/keystore.jks:/usr/share/app/configs/keystore.jks
@@ -52,7 +52,7 @@ services:
          options:
              max-file: "5"
              max-size: "100m"
-    command: bash -c "exec java $$RS_JAVA_OPTS  -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"
+    command: bash -c "exec java $$DI_JAVA_OPTS  -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"
 
 
   zookeeper:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,7 +9,7 @@ services:
   test:
     image: ghcr.io/datakaveri/di-test:latest
     environment:
-      - DI_URL=https://rs.iudx.org.in
+      - DI_URL=https://di.iudx.org.in
       - LOG_LEVEL=INFO
       - RS_JAVA_OPTS=-Xmx1024m
     volumes:
@@ -31,7 +31,7 @@ services:
   integTest:
     image: ghcr.io/datakaveri/di-test:latest
     environment:
-      - DI_URL=https://rs.iudx.org.in
+      - DI_URL=https://di.iudx.org.in
       - LOG_LEVEL=INFO
       - RS_JAVA_OPTS=-Xmx1024m
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   prod:
     image: iudx/di-depl:latest
     environment:
-      - DI_URL=https://rs.iudx.org.in
+      - DI_URL=https://di.iudx.org.in
       - LOG_LEVEL=INFO
       - DI_JAVA_OPTS=-Xmx4096m
     volumes:
@@ -35,7 +35,7 @@ services:
   dev:
     image: iudx/di-dev:latest
     environment:
-      - DI_URL=https://rs.iudx.org.in
+      - DI_URL=https://di.iudx.org.in
       - LOG_LEVEL=INFO
       - DI_JAVA_OPTS=-Xmx1024m
     volumes:

--- a/docker/build-push.sh
+++ b/docker/build-push.sh
@@ -5,8 +5,8 @@ MINOR_RELEASE=0
 COMMIT_ID=`git log  -1 --pretty=%h`
 # last commit id of master branch
 # To be executed from project root
-docker build -t dockerhub.iudx.io/iudx/di-depl:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID -f docker/depl.dockerfile . && \
-docker push dockerhub.iudx.io/iudx/di-depl:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID
+docker build -t ghcr.io/datakaveri/di-depl:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID -f docker/depl.dockerfile . && \
+docker push ghcr.io/datakaveri/di-depl:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID
 
-docker build -t dockerhub.iudx.io/iudx/di-dev:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID -f docker/dev.dockerfile . && \
-docker push dockerhub.iudx.io/iudx/di-dev:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID
+docker build -t ghcr.io/datakaveri/di-dev:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID -f docker/dev.dockerfile . && \
+docker push ghcr.io/datakaveri/di-dev:$MAJOR_RELEASE.$MINOR_RELEASE-$COMMIT_ID

--- a/docker/depl.dockerfile
+++ b/docker/depl.dockerfile
@@ -15,20 +15,16 @@ RUN mvn clean package -Dmaven.test.skip=true
 FROM openjdk:11-jre-slim-buster
 
 ARG VERSION
-ENV JAR="iudx.data.ingestion.server-dev-0.0.1-SNAPSHOT-fat.jar"
+ENV JAR="iudx.data.ingestion.server-cluster-0.0.1-SNAPSHOT-fat.jar"
 
 WORKDIR /usr/share/app
 # Copying openapi docs 
 COPY docs docs
 # Copying cluster fatjar from builder image stage to final image 
 COPY --from=builder /usr/share/app/target/${JAR} ./fatjar.jar
-# HTTP cat server port
-EXPOSE 8080
-# HTTPS cat server port
-EXPOSE 8443
-# Metrics http server port
-EXPOSE 9000 
-# creating a non-root user
+# expose http, https and metrics port
+EXPOSE 8080 8443 9000 
+# create non-root use 1001
 RUN useradd -r -u 1001 -g root di-user
 # Setting non-root user to use when container starts
 USER di-user

--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -21,8 +21,7 @@ WORKDIR /usr/share/app
 COPY docs docs
 # Copying dev fatjar from builder stage to final image
 COPY --from=builder /usr/share/app/target/${JAR} ./fatjar.jar
-EXPOSE 8080
-EXPOSE 8443
+EXPOSE 8080 8443
 # Creating a non-root user
 RUN useradd -r -u 1001 -g root di-user
 # Setting non-root user to use when container starts


### PR DESCRIPTION
@abhi270595 
* Reduced the size of the image in comparison to the previous image.
*  Created non-root image, having username ``di-user`` with uid ``1001``.

test:
1. checked ``docker top <container-name>``  and  the ``uid`` of process is ``1001``
```sh
hackcoderr@master-node:~/iudx/iudx-data-ingestion-server$ docker top de7
UID                 PID                 PPID                C                   STIME               TTY                 TIME                CMD
1001                25051               25030               7                   18:58               ?                   00:00:13            java -Xmx4096m -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar ./fatjar.jar --host de7b5d815f47 -c configs/config.json
```
2.  After exec into 
     i> checked the user, using ``id`` command - it has uid ``1001``.
  ```
di-user@de7b5d815f47:/usr/share/app$ id
uid=1001(di-user) gid=0(root) groups=0(root)
```

ii) tried to remove fatjar - it's not be able to remove the jar.
```
di-user@de7b5d815f47:/usr/share/app$ rm -f fatjar.jar 
rm: cannot remove 'fatjar.jar': Permission denied

```
     
Any changes are required, plz let me know.
