### PR TITLE
correct dockerfile,& remove PATH label in metric

### DIFF
--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -25,4 +25,4 @@ EXPOSE 8080 8443
 # Creating a non-root user
 RUN useradd -r -u 1001 -g root di-user
 # Setting non-root user to use when container starts
-USER id-user
+USER di-user

--- a/src/main/java/iudx/data/ingestion/server/deploy/Deployer.java
+++ b/src/main/java/iudx/data/ingestion/server/deploy/Deployer.java
@@ -157,7 +157,7 @@ public class Deployer {
 	                .setEmbeddedServerOptions(new HttpServerOptions().setPort(9000)))
 	        // .setPublishQuantiles(true))
 	        .setLabels(EnumSet.of(Label.EB_ADDRESS, Label.EB_FAILURE, Label.HTTP_CODE,
-	            Label.HTTP_METHOD, Label.HTTP_PATH))
+	            Label.HTTP_METHOD))
 	        .setEnabled(true);
 	  }
 


### PR DESCRIPTION
- PATH label, results in many metric series, hence need to  be removed. its patched in all other servers. Eg : https://github.com/datakaveri/iudx-resource-server/pull/133
- correct dev.dockefile with proper user