### PR TITLE
Make server items configurable 

### DIFF
--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -5,7 +5,9 @@
 	],
 	"clusterId": "iudx-di-cluster",
 	"commonConfig" : {
-		"dxApiBasePath" : "/ngsi-ld/v1"
+		"dxApiBasePath" : "/ngsi-ld/v1",
+		"dxCatalogueBasePath": "/iudx/cat/v1",
+		"dxAuthBasePath": "/auth/v1"
 	},
 	"modules": [
 		 {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -36,7 +36,9 @@ info:
     - **Base path**:
         - Base path is the path on which API is served, relative to the host
         - It is the initial part of the API
-        - The base path value could be configured according to the deployment
+        - These base path values could be configured according to the deployment
+        - The base path for [DX AAA Server](https://github.com/datakaveri/iudx-aaa-server) is set to `/auth/v1`
+        - The base path for [DX Catalogue Server](https://github.com/datakaveri/iudx-catalogue-server) is set to `/iudx/cat/v1`
         - Currently, the following APIs have `/ngsi-ld/v1` base path
             -  /entities
             -  /ingestion

--- a/src/main/java/iudx/data/ingestion/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/data/ingestion/server/apiserver/ApiServerVerticle.java
@@ -96,6 +96,8 @@ public class ApiServerVerticle extends AbstractVerticle {
   private MeteringService meteringService;
 
   private String dxApiBasePath;
+  private String dxCatalogueBasePath;
+  private String dxAuthBasePath;
   private JsonObject jsonConfiguration;
 
 
@@ -119,11 +121,10 @@ public class ApiServerVerticle extends AbstractVerticle {
     /* Define the APIs, methods, endpoints and associated methods. */
 
 
-//    jsonConfiguration = Configuration.getConfiguration();
-//    basePath = jsonConfiguration.getString(Configuration.NGSILD_BASEPATH);
-    
-    //LOGGER.debug(config());
+    /* Get base paths from config */
     dxApiBasePath=config().getString("dxApiBasePath");
+    dxCatalogueBasePath = config().getString("dxCatalogueBasePath");
+    dxAuthBasePath = config().getString("dxAuthBasePath");
     Api apis=Api.getInstance(dxApiBasePath);
 
     router = Router.router(vertx);

--- a/src/main/java/iudx/data/ingestion/server/apiserver/service/CatalogueService.java
+++ b/src/main/java/iudx/data/ingestion/server/apiserver/service/CatalogueService.java
@@ -1,6 +1,8 @@
 package iudx.data.ingestion.server.apiserver.service;
 
 import static iudx.data.ingestion.server.apiserver.util.Util.toList;
+import static iudx.data.ingestion.server.authenticator.Constants.CAT_ITEM_PATH;
+import static iudx.data.ingestion.server.authenticator.Constants.CAT_SEARCH_PATH;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -36,13 +38,15 @@ public class CatalogueService {
   public static WebClient catWebClient;
   private long cacheTimerid;
   private Vertx vertx;
+  private String catBasePath;
 
   public CatalogueService(Vertx vertx, JsonObject config) {
     this.vertx = vertx;
     catHost = config.getString("catServerHost");
     catPort = config.getInteger("catServerPort");
-    catSearchPath = Constants.CAT_RSG_PATH;
-    catItemPath = Constants.CAT_ITEM_PATH;
+    catBasePath = config.getString("dxCatalogueBasePath");
+    catItemPath = catBasePath + CAT_ITEM_PATH;
+    catSearchPath = catBasePath + CAT_SEARCH_PATH;
 
     WebClientOptions options =
         new WebClientOptions().setTrustAll(true).setVerifyHost(false).setSsl(true);

--- a/src/main/java/iudx/data/ingestion/server/authenticator/AuthenticationVerticle.java
+++ b/src/main/java/iudx/data/ingestion/server/authenticator/AuthenticationVerticle.java
@@ -16,6 +16,8 @@ import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.serviceproxy.ServiceBinder;
 import iudx.data.ingestion.server.common.Api;
 
+import static iudx.data.ingestion.server.authenticator.Constants.AUTH_CERTIFICATE_PATH;
+
 /**
  * The Authentication Verticle.
  * <h1>Authentication Verticle</h1>
@@ -106,7 +108,8 @@ public class AuthenticationVerticle extends AbstractVerticle {
   private Future<String> getJwtPublicKey(Vertx vertx, JsonObject config) {
     Promise<String> promise = Promise.promise();
     webClient = createWebClient(vertx, config);
-    webClient.get(443, config.getString("authServerHost"), "/auth/v1/cert").send(handler -> {
+    String authCert = config.getString("dxAuthBasePath") + AUTH_CERTIFICATE_PATH;
+    webClient.get(443, config.getString("authServerHost"), authCert).send(handler -> {
       if (handler.succeeded()) {
         JsonObject json = handler.result().bodyAsJsonObject();
         promise.complete(json.getString("cert"));

--- a/src/main/java/iudx/data/ingestion/server/authenticator/Constants.java
+++ b/src/main/java/iudx/data/ingestion/server/authenticator/Constants.java
@@ -10,8 +10,10 @@ public class Constants {
   public static final String KEYSTORE_PATH = "keystore";
   public static final String KEYSTORE_PASSWORD = "keystorePassword";
   public static final long CACHE_TIMEOUT_AMOUNT = 30;
-  public static final String CAT_RSG_PATH = "/iudx/cat/v1/search";
-  public static final String CAT_ITEM_PATH = "/iudx/cat/v1/item";
+  public static final String CAT_SEARCH_PATH = "/search";
+  public static final String AUTH_CERTIFICATE_PATH = "/cert";
+
+  public static final String CAT_ITEM_PATH = "/item";
   public static final String DI_AUDIENCE = "audience";
   public static final String CAT_SERVER_HOST = "catServerHost";
   public static final String CAT_SERVER_PORT = "catServerPort";

--- a/src/main/java/iudx/data/ingestion/server/authenticator/JwtAuthenticationServiceImpl.java
+++ b/src/main/java/iudx/data/ingestion/server/authenticator/JwtAuthenticationServiceImpl.java
@@ -38,6 +38,7 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
   final String path;
   final String audience;
   final Api apis;
+  final String catBasePath;
   final String authServerHost;
   // resourceGroupCache will contain ACL info about all resource group in ingestion server
   private final Cache<String, String> resourceGroupCache =
@@ -50,7 +51,8 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
     this.audience = config.getString(DI_AUDIENCE);
     host = config.getString(CAT_SERVER_HOST);
     port = config.getInteger(CAT_SERVER_PORT);
-    path = Constants.CAT_RSG_PATH;
+    this.catBasePath = config.getString("dxCatalogueBasePath");
+    this.path = catBasePath + CAT_SEARCH_PATH;
     this.apis=apis;
     authServerHost = config.getString("authServerHost");
     WebClientOptions options = new WebClientOptions();

--- a/src/test/java/iudx/data/ingestion/server/authenticator/JwtAuthServiceImplTest.java
+++ b/src/test/java/iudx/data/ingestion/server/authenticator/JwtAuthServiceImplTest.java
@@ -49,6 +49,8 @@ public class JwtAuthServiceImplTest {
     authConfig.put("authServerHost", "auth.test.com");
     authConfig.put("port", 1234);
     authConfig.put("dxApiBasePath","/ngsi-ld/v1");
+    authConfig.put("dxCatalogueBasePath", "/iudx/cat/v1");
+    authConfig.put("dxAuthBasePath", "/auth/v1");
 
     JWTAuthOptions jwtAuthOptions = new JWTAuthOptions();
     jwtAuthOptions.addPubSecKey(

--- a/src/test/resources/DI Jenkins Pipeline.postman_environment.json
+++ b/src/test/resources/DI Jenkins Pipeline.postman_environment.json
@@ -39,6 +39,11 @@
 			"enabled": true
 		},
 		{
+			"key": "dxAuthBasePath",
+			"value": "auth/v1",
+			"enabled": true
+		},
+		{
 			"key": "auth-url",
 			"value": "authvertx.iudx.io",
 			"type": "default",

--- a/src/test/resources/IUDX-Data-Ingestion-Server-APIs-V4.0.postman_collection.json
+++ b/src/test/resources/IUDX-Data-Ingestion-Server-APIs-V4.0.postman_collection.json
@@ -62,14 +62,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -130,14 +129,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -198,14 +196,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}

--- a/src/test/resources/README.md
+++ b/src/test/resources/README.md
@@ -1,8 +1,8 @@
 ### Making configurable base path
 - Base path can be added in postman environment file or in postman.
-- `DI Jenkins Pipeline.postman_environment.json` has **values** array which has a fields named **basePath** whose **value** is currently set to `ngsi-ld/v1`.
+- `DI Jenkins Pipeline.postman_environment.json` has **values** array which has fields named **basePath** whose **value** is currently set to `ngsi-ld/v1`, **dxAuthBasePath** with value `auth/v1`.
 - The **value** could be changed according to the deployment and then the collection with the `DI Jenkins Pipeline.postman_environment.json` file can be uploaded to Postman
-- For the changing the **basePath** value in postman after importing the collection and environment files, locate `DI Environment` from **Environments** in sidebar of Postman application.
+- For the changing the **basePath**, **dxAuthBasePath** value in postman after importing the collection and environment files, locate `DI Environment` from **Environments** in sidebar of Postman application.
 - To know more about Postman environments, refer : [postman environments](https://learning.postman.com/docs/sending-requests/managing-environments/)
 - The **CURRENT VALUE** of the variable could be changed
 


### PR DESCRIPTION
- Referencing datakaveri/iudx-resource-server#368
- Made Catalogue Server base path `iudx/cat/v1`, AAA Server base path `auth/v1` configurable by [updating the files](https://github.com/datakaveri/iudx-data-ingestion-server/pull/70/commits/00adbaaba0d13a484f354de13ef3f7846cd92017)
- Changes made in config-dev : 
```
"commonConfig" : {
		"dxApiBasePath" : "/ngsi-ld/v1",
		"dxCatalogueBasePath": "/iudx/cat/v1",
		"dxAuthBasePath": "/auth/v1"
	},
```
- Changes made in Postman environment file : 
```
		{
			"key": "dxAuthBasePath",
			"value": "auth/v1",
			"enabled": true
		},
```